### PR TITLE
fix-permission-error: initialize directories a little better

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV AWS_ACCESS_KEY="" \
 RUN apt-get update \
     && apt-get install -y curl unzip \
     && rm -rf /var/lib/apt/lists/* \
-    && groupadd ddns \
+    && groupadd ddns -g 1001 \
     && useradd -rm -d /opt/ddns -s /bin/bash -g ddns -G sudo -u 1001 ddns \
     && mkdir -p /app/terraform \
     && mkdir /app/terraform/.terraform

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd ddns \
     && useradd -rm -d /opt/ddns -s /bin/bash -g ddns -G sudo -u 1001 ddns \
-    && mkdir -p /app/terraform
+    && mkdir -p /app/terraform \
+    && mkdir /app/terraform/.terraform
 
 # Install Terraform
 ARG TERRAFORM_VERSION=1.3.4

--- a/README.md
+++ b/README.md
@@ -8,4 +8,6 @@
 
 A dynamic DNS CronJob on Kubernetes that runs Terraform against AWS Route53 to ensure the A-record is kept up-to-date with my residential IP. This service is only intended to run on home development clusters.
 
+The service persists the state file and terraform init artifacts in a PVC that's re-mounted on every run to the job.
+
 See also the [status page](https://premiscale-development.cronitorstatus.com/).

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -6,11 +6,11 @@
     cd terraform/ || exit 1 && \
     terraform init -input=false -no-color && \
     terraform plan -compact-warnings -input=false -no-color -state=.terraform/.terraform.tfstate -out terraform.plan \
-        -var "domain=premiscale.com" \
+        -var "domain=$DOMAIN" \
+        -var "domain_record=$DEVELOPMENT_A_RECORD" \
         -var "aws_access_key=$AWS_ACCESS_KEY" \
         -var "aws_secret_key=$AWS_SECRET_KEY" \
         -var "aws_region=$AWS_REGION" \
-        -var "domain_record=$A_RECORD" \
         -var "ip=$ME" && \
     terraform apply -compact-warnings -input=false -state=.terraform/.terraform.tfstate -auto-approve terraform.plan && \
     curl "https://cronitor.link/p/$CRONITOR_TELEMETRY_KEY/ddns?state=complete"

--- a/helm/ddns/values.yaml
+++ b/helm/ddns/values.yaml
@@ -29,16 +29,24 @@ cron:
       secretKeyRef:
         name: terraform
         key: AWS_REGION
+  # Cronitor.io telemetry API key.
   - name: CRONITOR_TELEMETRY_KEY
     valueFrom:
       secretKeyRef:
         name: cronitor
         key: CRONITOR_TELEMETRY_KEY
+  # A-record to keep up to date (that everything's CNAME'd-to).
   - name: DEVELOPMENT_A_RECORD
     valueFrom:
       secretKeyRef:
         name: terraform
         key: DEVELOPMENT_A_RECORD
+  # Target hosted zone.
+  - name: DOMAIN
+    valueFrom:
+      secretKeyRef:
+        name: terraform
+        key: DOMAIN
 
   resources:
     requests:

--- a/helm/ddns/values.yaml
+++ b/helm/ddns/values.yaml
@@ -61,7 +61,7 @@ cron:
 
   securityContext:
     runAsUser: 1001
-    fsGroup: ddns
+    fsGroup: 1001
     fsGroupChangePolicy: OnRootMismatch
 
 volume:

--- a/helm/ddns/values.yaml
+++ b/helm/ddns/values.yaml
@@ -53,6 +53,8 @@ cron:
 
   securityContext:
     runAsUser: 1001
+    fsGroup: ddns
+    fsGroupChangePolicy: OnRootMismatch
 
 volume:
   enabled: true

--- a/helm/ddns/values.yaml
+++ b/helm/ddns/values.yaml
@@ -6,7 +6,7 @@ global:
 
 cron:
   # Run hourly, 20 minutes after the top of the hour.
-  schedule: '20 * * * *'
+  schedule: '*/2 * * * *'
 
   image:
     name: ddns


### PR DESCRIPTION
Session:

```text
$ k logs -f ddns-28240040-24wjc
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   157  100   157    0     0    313      0 --:--:-- --:--:-- --:--:--   313
<html>
<head><title>502 Bad Gateway</title></head>
<body>
<center><h1>502 Bad Gateway</h1></center>
<hr><center>nginx/1.16.1</center>
</body>
</html>

Initializing the backend...

Initializing provider plugins...
- Reusing previous version of hashicorp/aws from the dependency lock file
- Installing hashicorp/aws v5.16.1...

Error: Failed to install provider

Error while installing hashicorp/aws v5.16.1: mkdir
.terraform/providers/registry.terraform.io/hashicorp/aws/5.16.1: permission
denied

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   157  100   157    0     0    284      0 --:--:-- --:--:-- --:--:--   284
<html>
<head><title>502 Bad Gateway</title></head>
<body>
<center><h1>502 Bad Gateway</h1></center>
<hr><center>nginx/1.16.1</center>
</body>
</html>
```