### PR TITLE
fix-missing-env-vars: resources and default env vars are missing

### DIFF
--- a/.circleci/helm.yml
+++ b/.circleci/helm.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 
 orbs:
-  general: bjd2385/general@0.7.7
+  general: bjd2385/general@0.7.8
 
 
 workflows:

--- a/helm/ddns/templates/cronjob.yaml
+++ b/helm/ddns/templates/cronjob.yaml
@@ -54,7 +54,7 @@ spec:
                 - name: {{ .Chart.Name }}
                   mountPath: /app/terraform/.terraform/
               {{- end }}
-              {{- with .Values.resources }}
+              {{- with .Values.cron.resources }}
               resources:
                 {{- toYaml . | nindent 16 }}
               {{- end }}

--- a/helm/ddns/templates/cronjob.yaml
+++ b/helm/ddns/templates/cronjob.yaml
@@ -45,7 +45,7 @@ spec:
               image: "{{ .Values.cron.image.name }}:{{ .Values.cron.image.tag }}"
               {{- end }}
               imagePullPolicy: Always
-              {{- with .Values.env }}
+              {{- with .Values.cron.env }}
               env:
                 {{- toYaml . | nindent 16 }}
               {{- end }}


### PR DESCRIPTION
- Missing env vars in template output. Probably didn't get applied to the cluster so there are no creds.